### PR TITLE
Add PHPxDMV

### DIFF
--- a/groups.json
+++ b/groups.json
@@ -12,5 +12,12 @@
 		"external": true,
 		"name": "PHP×GVL",
 		"region": "Greenville"
-	}
+	},
+    "phpxdmv.com": {
+        "bsky_url": "https://bsky.app/profile/phpxdmv.bsky.social",
+        "external": true,
+        "name": "PHPxDMV",
+        "region": "Washington D.C., Maryland, and Virginia",
+        "timezone": "America/New_York",
+    }
 }


### PR DESCRIPTION
I have purchased the phpxdmv.com domain to host meetups in the DMV (Washington D.C., Maryland, and Virginia) area.

I have marked the group as `external` until I can put up a landing page on the domain. I am open to joining the multi-tenant application, but I want to learn more about it before making that decision.