### PR TITLE
Add PHP×Vadodara

### DIFF
--- a/groups.json
+++ b/groups.json
@@ -251,5 +251,17 @@
         "bsky_url": "https://bsky.app/profile/phpxsea.com",
         "latitude": 47.60899936190318,
         "longitude": -122.34052530121367
+    },
+    "phpxvadodara.com": {
+        "external": false,
+        "name": "PHP×VADODARA",
+        "region": "Vadodara",
+        "continent": "ASIA",
+        "description": "A vibrant PHP meetup in the cultural city of Vadodara, India, connecting developers, enthusiasts, and artisans to share knowledge, learn, and grow together.",
+        "timezone": "Asia/Kolkata",
+        "status": "active",
+        "frequency": "monthly",
+        "latitude": 22.3174902,
+        "longitude": 73.1667258
     }
 }

--- a/groups.json
+++ b/groups.json
@@ -254,12 +254,12 @@
     },
     "phpxvadodara.com": {
         "external": false,
-        "name": "PHP×VADODARA",
+        "name": "PHP×Vadodara",
         "region": "Vadodara",
-        "continent": "ASIA",
+        "continent": "Asia",
         "description": "A vibrant PHP meetup in the cultural city of Vadodara, India, connecting developers, enthusiasts, and artisans to share knowledge, learn, and grow together.",
         "timezone": "Asia/Kolkata",
-        "status": "active",
+        "status": "planned",
         "frequency": "monthly",
         "latitude": 22.3174902,
         "longitude": 73.1667258

--- a/groups.json
+++ b/groups.json
@@ -265,7 +265,7 @@
         "bsky_url": null,
         "latitude": 36.16048,
         "longitude": -86.77842
-    }, {
+    },
     "phpxvadodara.com": {
         "external": false,
         "name": "PHP×Vadodara",


### PR DESCRIPTION
This PR adds a new entry for **PHP×VADODARA**, representing Vadodara, India, to the PHP×World ecosystem in `groups.json`. As a thriving hub for technology and innovation, Vadodara is home to an enthusiastic community of PHP developers and web artisans. We aspire to join the global PHP×World community to:  

- **Foster Collaboration**: Connect with developers worldwide to share insights, learn, and grow.  
- **Strengthen Community**: Build a strong local network while being part of the global PHP ecosystem.  
- **Encourage Knowledge Sharing**: Organize regular meetups to promote PHP, Laravel, and open-source technology.  

We believe this addition will bring value to PHP×World by introducing a passionate and skilled community from Vadodara. Let’s grow together and expand the reach of the PHP× initiative!  

Thank you for considering our contribution. 🙌