### PR TITLE
Use group timezone on meetup resource

### DIFF
--- a/app/Filament/Resources/MeetupResource.php
+++ b/app/Filament/Resources/MeetupResource.php
@@ -50,17 +50,17 @@ class MeetupResource extends Resource
 					->numeric()
 					->minValue(0),
 				Forms\Components\DateTimePicker::make('starts_at')
-                    ->timezone(function(Meetup $record){
-                        return $record->group?->timezone ?? 'UTC';
-                    })
+					->timezone(function(Meetup $record) {
+						return $record->group?->timezone ?? 'UTC';
+					})
 					->label('Start')
 					->required()
 					->beforeOrEqual('ends_at')
 					->rules(['required', 'date']),
 				Forms\Components\DateTimePicker::make('ends_at')
-                    ->timezone(function(Meetup $record){
-                        return $record->group?->timezone ?? 'UTC';
-                    })
+					->timezone(function(Meetup $record) {
+						return $record->group?->timezone ?? 'UTC';
+					})
 					->label('End')
 					->required()
 					->afterOrEqual('starts_at')

--- a/app/Filament/Resources/MeetupResource.php
+++ b/app/Filament/Resources/MeetupResource.php
@@ -15,14 +15,14 @@ use Filament\Tables\Table;
 class MeetupResource extends Resource
 {
 	protected static ?string $model = Meetup::class;
-	
+
 	protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
-	
+
 	public static function getNavigationBadge(): ?string
 	{
 		return Meetup::count();
 	}
-	
+
 	public static function form(Form $form): Form
 	{
 		return $form
@@ -33,7 +33,7 @@ class MeetupResource extends Resource
 						if ($group = request()->attributes->get('group')) {
 							return (string) $group->getKey();
 						}
-						
+
 						return null;
 					})
 					->searchable()
@@ -50,11 +50,17 @@ class MeetupResource extends Resource
 					->numeric()
 					->minValue(0),
 				Forms\Components\DateTimePicker::make('starts_at')
+                    ->timezone(function(Meetup $record){
+                        return $record->group?->timezone ?? 'UTC';
+                    })
 					->label('Start')
 					->required()
 					->beforeOrEqual('ends_at')
 					->rules(['required', 'date']),
 				Forms\Components\DateTimePicker::make('ends_at')
+                    ->timezone(function(Meetup $record){
+                        return $record->group?->timezone ?? 'UTC';
+                    })
 					->label('End')
 					->required()
 					->afterOrEqual('starts_at')
@@ -64,7 +70,7 @@ class MeetupResource extends Resource
 					->columnSpanFull(),
 			]);
 	}
-	
+
 	public static function table(Table $table): Table
 	{
 		return $table
@@ -112,14 +118,14 @@ class MeetupResource extends Resource
 				]),
 			]);
 	}
-	
+
 	public static function getRelations(): array
 	{
 		return [
 			RelationManagers\UsersRelationManager::class,
 		];
 	}
-	
+
 	public static function getPages(): array
 	{
 		return [

--- a/app/Filament/Resources/MeetupResource.php
+++ b/app/Filament/Resources/MeetupResource.php
@@ -50,16 +50,16 @@ class MeetupResource extends Resource
 					->numeric()
 					->minValue(0),
 				Forms\Components\DateTimePicker::make('starts_at')
-					->timezone(function(Meetup $record) {
-						return $record->group?->timezone ?? 'UTC';
+					->timezone(function(?Meetup $record) {
+						return $record?->group?->timezone ?? 'UTC';
 					})
 					->label('Start')
 					->required()
 					->beforeOrEqual('ends_at')
 					->rules(['required', 'date']),
 				Forms\Components\DateTimePicker::make('ends_at')
-					->timezone(function(Meetup $record) {
-						return $record->group?->timezone ?? 'UTC';
+					->timezone(function(?Meetup $record) {
+						return $record?->group?->timezone ?? 'UTC';
 					})
 					->label('End')
 					->required()


### PR DESCRIPTION
This fixes #39 

Currently we have to select a UTC datetime for `starts_at` and `ends_at` fields in the Meetup create/update pages. 
Ideally we select dates according to the group's timezone. The datetime saved in the DB is still in UTC. 