### PR TITLE
Feature: Sponsorships

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,11 @@
+{
+    "mcpServers": {
+        "laravel-boost": {
+            "command": "php",
+            "args": [
+                "artisan",
+                "boost:mcp"
+            ]
+        }
+    }
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,423 @@
+<laravel-boost-guidelines>
+=== foundation rules ===
+
+# Laravel Boost Guidelines
+
+The Laravel Boost guidelines are specifically curated by Laravel maintainers for this application. These guidelines should be followed closely to enhance the user's satisfaction building Laravel applications.
+
+## Foundational Context
+This application is a Laravel application and its main Laravel ecosystems package & versions are below. You are an expert with them all. Ensure you abide by these specific packages & versions.
+
+- php - 8.3.24
+- filament/filament (FILAMENT) - v3
+- laravel/framework (LARAVEL) - v11
+- laravel/prompts (PROMPTS) - v0
+- laravel/socialite (SOCIALITE) - v5
+- livewire/livewire (LIVEWIRE) - v3
+- laravel/pint (PINT) - v1
+- laravel/sail (SAIL) - v1
+- alpinejs (ALPINEJS) - v3
+- tailwindcss (TAILWINDCSS) - v3
+
+
+## Conventions
+- You must follow all existing code conventions used in this application. When creating or editing a file, check sibling files for the correct structure, approach, naming.
+- Use descriptive names for variables and methods. For example, `isRegisteredForDiscounts`, not `discount()`.
+- Check for existing components to reuse before writing a new one.
+
+## Verification Scripts
+- Do not create verification scripts or tinker when tests cover that functionality and prove it works. Unit and feature tests are more important.
+
+## Application Structure & Architecture
+- Stick to existing directory structure - don't create new base folders without approval.
+- Do not change the application's dependencies without approval.
+
+## Frontend Bundling
+- If the user doesn't see a frontend change reflected in the UI, it could mean they need to run `npm run build`, `npm run dev`, or `composer run dev`. Ask them.
+
+## Replies
+- Be concise in your explanations - focus on what's important rather than explaining obvious details.
+
+## Documentation Files
+- You must only create documentation files if explicitly requested by the user.
+
+
+=== boost rules ===
+
+## Laravel Boost
+- Laravel Boost is an MCP server that comes with powerful tools designed specifically for this application. Use them.
+
+## Artisan
+- Use the `list-artisan-commands` tool when you need to call an Artisan command to double check the available parameters.
+
+## URLs
+- Whenever you share a project URL with the user you should use the `get-absolute-url` tool to ensure you're using the correct scheme, domain / IP, and port.
+
+## Tinker / Debugging
+- You should use the `tinker` tool when you need to execute PHP to debug code or query Eloquent models directly.
+- Use the `database-query` tool when you only need to read from the database.
+
+## Reading Browser Logs With the `browser-logs` Tool
+- You can read browser logs, errors, and exceptions using the `browser-logs` tool from Boost.
+- Only recent browser logs will be useful - ignore old logs.
+
+## Searching Documentation (Critically Important)
+- Boost comes with a powerful `search-docs` tool you should use before any other approaches. This tool automatically passes a list of installed packages and their versions to the remote Boost API, so it returns only version-specific documentation specific for the user's circumstance. You should pass an array of packages to filter on if you know you need docs for particular packages.
+- The 'search-docs' tool is perfect for all Laravel related packages, including Laravel, Inertia, Livewire, Filament, Tailwind, Pest, Nova, Nightwatch, etc.
+- You must use this tool to search for Laravel-ecosystem documentation before falling back to other approaches.
+- Search the documentation before making code changes to ensure we are taking the correct approach.
+- Use multiple, broad, simple, topic based queries to start. For example: `['rate limiting', 'routing rate limiting', 'routing']`.
+- Do not add package names to queries - package information is already shared. For example, use `test resource table`, not `filament 4 test resource table`.
+
+### Available Search Syntax
+- You can and should pass multiple queries at once. The most relevant results will be returned first.
+
+1. Simple Word Searches with auto-stemming - query=authentication - finds 'authenticate' and 'auth'
+2. Multiple Words (AND Logic) - query=rate limit - finds knowledge containing both "rate" AND "limit"
+3. Quoted Phrases (Exact Position) - query="infinite scroll" - Words must be adjacent and in that order
+4. Mixed Queries - query=middleware "rate limit" - "middleware" AND exact phrase "rate limit"
+5. Multiple Queries - queries=["authentication", "middleware"] - ANY of these terms
+
+
+=== php rules ===
+
+## PHP
+
+- Always use curly braces for control structures, even if it has one line.
+
+### Constructors
+- Use PHP 8 constructor property promotion in `__construct()`.
+    - <code-snippet>public function __construct(public GitHub $github) { }</code-snippet>
+- Do not allow empty `__construct()` methods with zero parameters.
+
+### Type Declarations
+- Always use explicit return type declarations for methods and functions.
+- Use appropriate PHP type hints for method parameters.
+
+<code-snippet name="Explicit Return Types and Method Params" lang="php">
+protected function isAccessible(User $user, ?string $path = null): bool
+{
+    ...
+}
+</code-snippet>
+
+## Comments
+- Prefer PHPDoc blocks over comments. Never use comments within the code itself unless there is something _very_ complex going on.
+
+## PHPDoc Blocks
+- Add useful array shape type definitions for arrays when appropriate.
+
+## Enums
+- That being said, keys in an Enum should follow existing application Enum conventions.
+
+
+=== herd rules ===
+
+## Laravel Herd
+
+- The application is served by Laravel Herd and will be available at: https?://[kebab-case-project-dir].test. Use the `get-absolute-url` tool to generate URLs for the user to ensure valid URLs.
+- You must not run any commands to make the site available via HTTP(s). It is _always_ available through Laravel Herd.
+
+
+=== filament/core rules ===
+
+## Filament
+- Filament is used by this application, check how and where to follow existing application conventions.
+- Filament is a Server-Driven UI (SDUI) framework for Laravel. It allows developers to define user interfaces in PHP using structured configuration objects. It is built on top of Livewire, Alpine.js, and Tailwind CSS.
+- You can use the `search-docs` tool to get information from the official Filament documentation when needed. This is very useful for Artisan command arguments, specific code examples, testing functionality, relationship management, and ensuring you're following idiomatic practices.
+- Utilize static `make()` methods for consistent component initialization.
+
+### Artisan
+- You must use the Filament specific Artisan commands to create new files or components for Filament. You can find these with the `list-artisan-commands` tool, or with `php artisan` and the `--help` option.
+- Inspect the required options, always pass `--no-interaction`, and valid arguments for other options when applicable.
+
+### Filament's Core Features
+- Actions: Handle doing something within the application, often with a button or link. Actions encapsulate the UI, the interactive modal window, and the logic that should be executed when the modal window is submitted. They can be used anywhere in the UI and are commonly used to perform one-time actions like deleting a record, sending an email, or updating data in the database based on modal form input.
+- Forms: Dynamic forms rendered within other features, such as resources, action modals, table filters, and more.
+- Infolists: Read-only lists of data.
+- Notifications: Flash notifications displayed to users within the application.
+- Panels: The top-level container in Filament that can include all other features like pages, resources, forms, tables, notifications, actions, infolists, and widgets.
+- Resources: Static classes that are used to build CRUD interfaces for Eloquent models. Typically live in `app/Filament/Resources`.
+- Schemas: Represent components that define the structure and behavior of the UI, such as forms, tables, or lists.
+- Tables: Interactive tables with filtering, sorting, pagination, and more.
+- Widgets: Small component included within dashboards, often used for displaying data in charts, tables, or as a stat.
+
+### Relationships
+- Determine if you can use the `relationship()` method on form components when you need `options` for a select, checkbox, repeater, or when building a `Fieldset`:
+
+<code-snippet name="Relationship example for Form Select" lang="php">
+Forms\Components\Select::make('user_id')
+    ->label('Author')
+    ->relationship('author')
+    ->required(),
+</code-snippet>
+
+
+## Testing
+- It's important to test Filament functionality for user satisfaction.
+- Ensure that you are authenticated to access the application within the test.
+- Filament uses Livewire, so start assertions with `livewire()` or `Livewire::test()`.
+
+### Example Tests
+
+<code-snippet name="Filament Table Test" lang="php">
+    livewire(ListUsers::class)
+        ->assertCanSeeTableRecords($users)
+        ->searchTable($users->first()->name)
+        ->assertCanSeeTableRecords($users->take(1))
+        ->assertCanNotSeeTableRecords($users->skip(1))
+        ->searchTable($users->last()->email)
+        ->assertCanSeeTableRecords($users->take(-1))
+        ->assertCanNotSeeTableRecords($users->take($users->count() - 1));
+</code-snippet>
+
+<code-snippet name="Filament Create Resource Test" lang="php">
+    livewire(CreateUser::class)
+        ->fillForm([
+            'name' => 'Howdy',
+            'email' => 'howdy@example.com',
+        ])
+        ->call('create')
+        ->assertNotified()
+        ->assertRedirect();
+
+    assertDatabaseHas(User::class, [
+        'name' => 'Howdy',
+        'email' => 'howdy@example.com',
+    ]);
+</code-snippet>
+
+<code-snippet name="Testing Multiple Panels (setup())" lang="php">
+    use Filament\Facades\Filament;
+
+    Filament::setCurrentPanel('app');
+</code-snippet>
+
+<code-snippet name="Calling an Action in a Test" lang="php">
+    livewire(EditInvoice::class, [
+        'invoice' => $invoice,
+    ])->callAction('send');
+
+    expect($invoice->refresh())->isSent()->toBeTrue();
+</code-snippet>
+
+
+=== filament/v3 rules ===
+
+## Filament 3
+
+## Version 3 Changes To Focus On
+- Resources are located in `app/Filament/Resources/` directory.
+- Resource pages (List, Create, Edit) are auto-generated within the resource's directory - e.g., `app/Filament/Resources/PostResource/Pages/`.
+- Forms use the `Forms\Components` namespace for form fields.
+- Tables use the `Tables\Columns` namespace for table columns.
+- A new `Filament\Forms\Components\RichEditor` component is available.
+- Form and table schemas now use fluent method chaining.
+- Added `php artisan filament:optimize` command for production optimization.
+- Requires implementing `FilamentUser` contract for production access control.
+
+
+=== laravel/core rules ===
+
+## Do Things the Laravel Way
+
+- Use `php artisan make:` commands to create new files (i.e. migrations, controllers, models, etc.). You can list available Artisan commands using the `list-artisan-commands` tool.
+- If you're creating a generic PHP class, use `artisan make:class`.
+- Pass `--no-interaction` to all Artisan commands to ensure they work without user input. You should also pass the correct `--options` to ensure correct behavior.
+
+### Database
+- Always use proper Eloquent relationship methods with return type hints. Prefer relationship methods over raw queries or manual joins.
+- Use Eloquent models and relationships before suggesting raw database queries
+- Avoid `DB::`; prefer `Model::query()`. Generate code that leverages Laravel's ORM capabilities rather than bypassing them.
+- Generate code that prevents N+1 query problems by using eager loading.
+- Use Laravel's query builder for very complex database operations.
+
+### Model Creation
+- When creating new models, create useful factories and seeders for them too. Ask the user if they need any other things, using `list-artisan-commands` to check the available options to `php artisan make:model`.
+
+### APIs & Eloquent Resources
+- For APIs, default to using Eloquent API Resources and API versioning unless existing API routes do not, then you should follow existing application convention.
+
+### Controllers & Validation
+- Always create Form Request classes for validation rather than inline validation in controllers. Include both validation rules and custom error messages.
+- Check sibling Form Requests to see if the application uses array or string based validation rules.
+
+### Queues
+- Use queued jobs for time-consuming operations with the `ShouldQueue` interface.
+
+### Authentication & Authorization
+- Use Laravel's built-in authentication and authorization features (gates, policies, Sanctum, etc.).
+
+### URL Generation
+- When generating links to other pages, prefer named routes and the `route()` function.
+
+### Configuration
+- Use environment variables only in configuration files - never use the `env()` function directly outside of config files. Always use `config('app.name')`, not `env('APP_NAME')`.
+
+### Testing
+- When creating models for tests, use the factories for the models. Check if the factory has custom states that can be used before manually setting up the model.
+- Faker: Use methods such as `$this->faker->word()` or `fake()->randomDigit()`. Follow existing conventions whether to use `$this->faker` or `fake()`.
+- When creating tests, make use of `php artisan make:test [options] <name>` to create a feature test, and pass `--unit` to create a unit test. Most tests should be feature tests.
+
+### Vite Error
+- If you receive an "Illuminate\Foundation\ViteException: Unable to locate file in Vite manifest" error, you can run `npm run build` or ask the user to run `npm run dev` or `composer run dev`.
+
+
+=== laravel/v11 rules ===
+
+## Laravel 11
+
+- Use the `search-docs` tool to get version specific documentation.
+- Laravel 11 brought a new streamlined file structure which this project now uses.
+
+### Laravel 11 Structure
+- No middleware files in `app/Http/Middleware/`.
+- `bootstrap/app.php` is the file to register middleware, exceptions, and routing files.
+- `bootstrap/providers.php` contains application specific service providers.
+- **No app\Console\Kernel.php** - use `bootstrap/app.php` or `routes/console.php` for console configuration.
+- **Commands auto-register** - files in `app/Console/Commands/` are automatically available and do not require manual registration.
+
+### Database
+- When modifying a column, the migration must include all of the attributes that were previously defined on the column. Otherwise, they will be dropped and lost.
+- Laravel 11 allows limiting eagerly loaded records natively, without external packages: `$query->latest()->limit(10);`.
+
+### Models
+- Casts can and likely should be set in a `casts()` method on a model rather than the `$casts` property. Follow existing conventions from other models.
+
+### New Artisan Commands
+- List Artisan commands using Boost's MCP tool, if available. New commands available in Laravel 11:
+    - `php artisan make:enum`
+    - `php artisan make:class`
+    - `php artisan make:interface`
+
+
+=== livewire/core rules ===
+
+## Livewire Core
+- Use the `search-docs` tool to find exact version specific documentation for how to write Livewire & Livewire tests.
+- Use the `php artisan make:livewire [Posts\\CreatePost]` artisan command to create new components
+- State should live on the server, with the UI reflecting it.
+- All Livewire requests hit the Laravel backend, they're like regular HTTP requests. Always validate form data, and run authorization checks in Livewire actions.
+
+## Livewire Best Practices
+- Livewire components require a single root element.
+- Use `wire:loading` and `wire:dirty` for delightful loading states.
+- Add `wire:key` in loops:
+
+    ```blade
+    @foreach ($items as $item)
+        <div wire:key="item-{{ $item->id }}">
+            {{ $item->name }}
+        </div>
+    @endforeach
+    ```
+
+- Prefer lifecycle hooks like `mount()`, `updatedFoo()`) for initialization and reactive side effects:
+
+<code-snippet name="Lifecycle hook examples" lang="php">
+    public function mount(User $user) { $this->user = $user; }
+    public function updatedSearch() { $this->resetPage(); }
+</code-snippet>
+
+
+## Testing Livewire
+
+<code-snippet name="Example Livewire component test" lang="php">
+    Livewire::test(Counter::class)
+        ->assertSet('count', 0)
+        ->call('increment')
+        ->assertSet('count', 1)
+        ->assertSee(1)
+        ->assertStatus(200);
+</code-snippet>
+
+
+    <code-snippet name="Testing a Livewire component exists within a page" lang="php">
+        $this->get('/posts/create')
+        ->assertSeeLivewire(CreatePost::class);
+    </code-snippet>
+
+
+=== livewire/v3 rules ===
+
+## Livewire 3
+
+### Key Changes From Livewire 2
+- These things changed in Livewire 2, but may not have been updated in this application. Verify this application's setup to ensure you conform with application conventions.
+    - Use `wire:model.live` for real-time updates, `wire:model` is now deferred by default.
+    - Components now use the `App\Livewire` namespace (not `App\Http\Livewire`).
+    - Use `$this->dispatch()` to dispatch events (not `emit` or `dispatchBrowserEvent`).
+    - Use the `components.layouts.app` view as the typical layout path (not `layouts.app`).
+
+### New Directives
+- `wire:show`, `wire:transition`, `wire:cloak`, `wire:offline`, `wire:target` are available for use. Use the documentation to find usage examples.
+
+### Alpine
+- Alpine is now included with Livewire, don't manually include Alpine.js.
+- Plugins included with Alpine: persist, intersect, collapse, and focus.
+
+### Lifecycle Hooks
+- You can listen for `livewire:init` to hook into Livewire initialization, and `fail.status === 419` for the page expiring:
+
+<code-snippet name="livewire:load example" lang="js">
+document.addEventListener('livewire:init', function () {
+    Livewire.hook('request', ({ fail }) => {
+        if (fail && fail.status === 419) {
+            alert('Your session expired');
+        }
+    });
+
+    Livewire.hook('message.failed', (message, component) => {
+        console.error(message);
+    });
+});
+</code-snippet>
+
+
+=== pint/core rules ===
+
+## Laravel Pint Code Formatter
+
+- You must run `vendor/bin/pint --dirty` before finalizing changes to ensure your code matches the project's expected style.
+- Do not run `vendor/bin/pint --test`, simply run `vendor/bin/pint` to fix any formatting issues.
+
+
+=== tailwindcss/core rules ===
+
+## Tailwind Core
+
+- Use Tailwind CSS classes to style HTML, check and use existing tailwind conventions within the project before writing your own.
+- Offer to extract repeated patterns into components that match the project's conventions (i.e. Blade, JSX, Vue, etc..)
+- Think through class placement, order, priority, and defaults - remove redundant classes, add classes to parent or child carefully to limit repetition, group elements logically
+- You can use the `search-docs` tool to get exact examples from the official documentation when needed.
+
+### Spacing
+- When listing items, use gap utilities for spacing, don't use margins.
+
+    <code-snippet name="Valid Flex Gap Spacing Example" lang="html">
+        <div class="flex gap-8">
+            <div>Superior</div>
+            <div>Michigan</div>
+            <div>Erie</div>
+        </div>
+    </code-snippet>
+
+
+### Dark Mode
+- If existing pages and components support dark mode, new pages and components must support dark mode in a similar way, typically using `dark:`.
+
+
+=== tailwindcss/v3 rules ===
+
+## Tailwind 3
+
+- Always use Tailwind CSS v3 - verify you're using only classes supported by this version.
+
+
+=== tests rules ===
+
+## Test Enforcement
+
+- Every change must be programmatically tested. Write a new test or update an existing test, then run the affected tests to make sure they pass.
+- Run the minimum number of tests needed to ensure code quality and speed. Use `php artisan test` with a specific filename or filter.
+</laravel-boost-guidelines>

--- a/README.md
+++ b/README.md
@@ -27,11 +27,19 @@ to `true`.
 If you would like to start a new PHP× group, please check our [Organizers page](/organizers)
 for instructions and considerations.
 
+### Adding sponsorship packages
+
+PHP× groups can now display sponsorship information directly on their pages! Visit our
+[Sponsorships page](/sponsorships) to learn how to add sponsorship packages to your group
+and see best practices for working with sponsors.
+
 ## Sponsoring Groups
 
-If you are a company that would like to sponsor PHP and Laravel events, please get in
-touch. The best way to do that, right now, is [via the PHP× Discord](https://discord.gg/wMy6Eeuwbu).
-In the future, we plan to make it easier to connect groups with sponsors.
+If you are a company that would like to sponsor PHP and Laravel events, please visit our
+[Sponsorships page](/sponsorships) to see groups currently looking for sponsors and learn
+about the benefits of sponsoring PHP× meetups.
+
+You can also connect with organizers directly [via the PHP× Discord](https://discord.gg/wMy6Eeuwbu).
 
 ## The PHP× network of sites
 

--- a/app/Actions/SyncGroups.php
+++ b/app/Actions/SyncGroups.php
@@ -91,6 +91,8 @@ class SyncGroups
 			'longitude',
 		]));
 		
+		$this->syncSponsorship($group, $config);
+		
 		return $group;
 	}
 	
@@ -109,6 +111,23 @@ class SyncGroups
 		]));
 		
 		return $external_group;
+	}
+	
+	protected function syncSponsorship(Group $group, array $config): void
+	{
+		if (isset($config['sponsorships'])) {
+			$sponsorship = $config['sponsorships'];
+			
+			$group->sponsorships_enabled = (bool) ($sponsorship['enabled'] ?? false);
+			$group->sponsorship_packages = $sponsorship['packages'] ?? [];
+			$group->sponsorship_contact_email = $sponsorship['contact_email'] ?? null;
+			$group->sponsorship_description = $sponsorship['description'] ?? null;
+		} else {
+			$group->sponsorships_enabled = false;
+			$group->sponsorship_packages = [];
+			$group->sponsorship_contact_email = null;
+			$group->sponsorship_description = null;
+		}
 	}
 	
 	/** @return Collection<string, Group|ExternalGroup> */

--- a/app/Http/Controllers/World/SponsorshipsController.php
+++ b/app/Http/Controllers/World/SponsorshipsController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace App\Http\Controllers\World;
+
+use App\Models\Group;
+use Illuminate\Http\Request;
+
+class SponsorshipsController
+{
+    public function __invoke(Request $request)
+    {
+        $groupsWithSponsorship = Group::where('sponsorships_enabled', true)
+            ->whereNotNull('sponsorship_packages')
+            ->where('sponsorship_packages', '!=', '[]')
+            ->orderBy('name')
+            ->get();
+
+        return view('world.sponsorships', [
+            'groupsWithSponsorship' => $groupsWithSponsorship
+        ]);
+    }
+}

--- a/app/Models/Group.php
+++ b/app/Models/Group.php
@@ -45,6 +45,10 @@ class Group extends Model
 		'custom_open_graph_image',
 		'latitude',
 		'longitude',
+		'sponsorships_enabled',
+		'sponsorship_packages',
+		'sponsorship_contact_email', 
+		'sponsorship_description',
 		'created_at',
 	];
 	
@@ -78,6 +82,16 @@ class Group extends Model
 	public function isDisbanded(): bool
 	{
 		return GroupStatus::Disbanded === $this->status;
+	}
+	
+	public function acceptsSponsorship(): bool
+	{
+		return $this->sponsorships_enabled;
+	}
+	
+	public function hasSponsorship(): bool
+	{
+		return $this->acceptsSponsorship() && ! empty($this->sponsorship_packages);
 	}
 	
 	public function mailcoach(): ?Mailcoach
@@ -139,6 +153,8 @@ class Group extends Model
 			'domain_status' => DomainStatus::class,
 			'latitude' => 'float',
 			'longitude' => 'float',
+			'sponsorships_enabled' => 'boolean',
+			'sponsorship_packages' => 'array',
 		];
 	}
 	

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "fakerphp/faker": "^1.23",
         "friendsofphp/php-cs-fixer": "^3.68",
         "itsgoingd/clockwork": "^5.3",
+        "laravel/boost": "^1.0",
         "laravel/pint": "^1.13",
         "laravel/sail": "^1.26",
         "mockery/mockery": "^1.6",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c54da3d3a50787fa6245951be1084888",
+    "content-hash": "34712b6749834e66dc8aa69e10ca0822",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",
@@ -10031,6 +10031,135 @@
             "time": "2025-02-09T15:57:21+00:00"
         },
         {
+            "name": "laravel/boost",
+            "version": "v1.0.20",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/boost.git",
+                "reference": "c2ac67ce42c39ffe6c3c073c9202d54a96eaa5b5"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/boost/zipball/c2ac67ce42c39ffe6c3c073c9202d54a96eaa5b5",
+                "reference": "c2ac67ce42c39ffe6c3c073c9202d54a96eaa5b5",
+                "shasum": ""
+            },
+            "require": {
+                "guzzlehttp/guzzle": "^7.9",
+                "illuminate/console": "^10.0|^11.0|^12.0",
+                "illuminate/contracts": "^10.0|^11.0|^12.0",
+                "illuminate/routing": "^10.0|^11.0|^12.0",
+                "illuminate/support": "^10.0|^11.0|^12.0",
+                "laravel/mcp": "^0.1.1",
+                "laravel/prompts": "^0.1.9|^0.3",
+                "laravel/roster": "^0.2.4",
+                "php": "^8.1"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.14",
+                "mockery/mockery": "^1.6",
+                "orchestra/testbench": "^8.22.0|^9.0|^10.0",
+                "pestphp/pest": "^2.0|^3.0",
+                "phpstan/phpstan": "^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Boost\\BoostServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Boost\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Laravel Boost accelerates AI-assisted development to generate high-quality, Laravel-specific code.",
+            "homepage": "https://github.com/laravel/boost",
+            "keywords": [
+                "ai",
+                "dev",
+                "laravel"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/boost/issues",
+                "source": "https://github.com/laravel/boost"
+            },
+            "time": "2025-08-28T14:46:17+00:00"
+        },
+        {
+            "name": "laravel/mcp",
+            "version": "v0.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/mcp.git",
+                "reference": "6d6284a491f07c74d34f48dfd999ed52c567c713"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/mcp/zipball/6d6284a491f07c74d34f48dfd999ed52c567c713",
+                "reference": "6d6284a491f07c74d34f48dfd999ed52c567c713",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/console": "^10.0|^11.0|^12.0",
+                "illuminate/contracts": "^10.0|^11.0|^12.0",
+                "illuminate/http": "^10.0|^11.0|^12.0",
+                "illuminate/routing": "^10.0|^11.0|^12.0",
+                "illuminate/support": "^10.0|^11.0|^12.0",
+                "illuminate/validation": "^10.0|^11.0|^12.0",
+                "php": "^8.1|^8.2"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.14",
+                "orchestra/testbench": "^8.22.0|^9.0|^10.0",
+                "phpstan/phpstan": "^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "aliases": {
+                        "Mcp": "Laravel\\Mcp\\Server\\Facades\\Mcp"
+                    },
+                    "providers": [
+                        "Laravel\\Mcp\\Server\\McpServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Mcp\\": "src/",
+                    "Workbench\\App\\": "workbench/app/",
+                    "Laravel\\Mcp\\Tests\\": "tests/",
+                    "Laravel\\Mcp\\Server\\": "src/Server/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The easiest way to add MCP servers to your Laravel app.",
+            "homepage": "https://github.com/laravel/mcp",
+            "keywords": [
+                "dev",
+                "laravel",
+                "mcp"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/mcp/issues",
+                "source": "https://github.com/laravel/mcp"
+            },
+            "time": "2025-08-16T09:50:43+00:00"
+        },
+        {
             "name": "laravel/pint",
             "version": "v1.20.0",
             "source": {
@@ -10095,6 +10224,67 @@
                 "source": "https://github.com/laravel/pint"
             },
             "time": "2025-01-14T16:20:53+00:00"
+        },
+        {
+            "name": "laravel/roster",
+            "version": "v0.2.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/roster.git",
+                "reference": "0252fa419733c61b3ebeba8e4e2b9ad2a63f3a17"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/roster/zipball/0252fa419733c61b3ebeba8e4e2b9ad2a63f3a17",
+                "reference": "0252fa419733c61b3ebeba8e4e2b9ad2a63f3a17",
+                "shasum": ""
+            },
+            "require": {
+                "illuminate/console": "^10.0|^11.0|^12.0",
+                "illuminate/contracts": "^10.0|^11.0|^12.0",
+                "illuminate/routing": "^10.0|^11.0|^12.0",
+                "illuminate/support": "^10.0|^11.0|^12.0",
+                "php": "^8.1|^8.2",
+                "symfony/yaml": "^6.4|^7.2"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.14",
+                "mockery/mockery": "^1.6",
+                "orchestra/testbench": "^8.22.0|^9.0|^10.0",
+                "pestphp/pest": "^2.0|^3.0",
+                "phpstan/phpstan": "^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Roster\\RosterServiceProvider"
+                    ]
+                },
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Roster\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Detect packages & approaches in use within a Laravel project",
+            "homepage": "https://github.com/laravel/roster",
+            "keywords": [
+                "dev",
+                "laravel"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/roster/issues",
+                "source": "https://github.com/laravel/roster"
+            },
+            "time": "2025-08-29T07:47:42+00:00"
         },
         {
             "name": "laravel/sail",

--- a/database/migrations/2025_08_30_141855_add_sponsorship_fields_to_groups_table.php
+++ b/database/migrations/2025_08_30_141855_add_sponsorship_fields_to_groups_table.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('groups', function (Blueprint $table) {
+            $table->boolean('sponsorships_enabled')->default(false);
+            $table->json('sponsorship_packages')->nullable();
+            $table->string('sponsorship_contact_email')->nullable();
+            $table->text('sponsorship_description')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('groups', function (Blueprint $table) {
+            $table->dropColumn([
+                'sponsorships_enabled',
+                'sponsorship_packages', 
+                'sponsorship_contact_email',
+                'sponsorship_description'
+            ]);
+        });
+    }
+};

--- a/resources/views/components/sponsorship-info.blade.php
+++ b/resources/views/components/sponsorship-info.blade.php
@@ -1,0 +1,55 @@
+@props(['group'])
+
+@if($group->hasSponsorship())
+	<div class="w-full mt-8">
+		<h1 class="font-mono font-semibold text-white text-2xl mb-4">
+			Sponsor Our Meetup
+		</h3>
+		
+		@if($group->sponsorship_description)
+			<p class="text-gray-300 mb-6">{{ $group->sponsorship_description }}</p>
+		@endif
+		
+		<div class="space-y-4">
+			@foreach($group->sponsorship_packages as $package)
+				<div class="bg-white/5 rounded-lg p-4 border border-white/5">
+					<div class="flex justify-between items-start mb-3">
+						<h4 class="text-lg font-semibold text-white">{{ $package['name'] }}</h4>
+						<span class="text-xl font-bold text-white">
+							{{ strtoupper($package['currency']) }} ${{ number_format($package['amount']) }}
+						</span>
+					</div>
+					
+					@if(isset($package['benefits']) && count($package['benefits']) > 0)
+						<ul class="text-sm text-gray-300 space-y-1">
+							@foreach($package['benefits'] as $benefit)
+								<li class="flex items-start gap-2">
+									<svg class="w-4 h-4 text-green-400 mt-0.5 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+										<path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd" />
+									</svg>
+									{{ $benefit }}
+								</li>
+							@endforeach
+						</ul>
+					@endif
+				</div>
+			@endforeach
+		</div>
+		
+		@if($group->sponsorship_contact_email)
+			<div class="mt-6 pt-6 border-t border-white/10">
+				<div class="flex items-center gap-3">
+					<svg class="w-6 h-6 text-white opacity-70" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M3 8l7.89 4.26a2 2 0 002.22 0L21 8M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z" />
+					</svg>
+					<div>
+						<p class="text-sm text-gray-300">Interested in sponsoring?</p>
+						<a href="mailto:{{ $group->sponsorship_contact_email }}" class="text-white hover:underline font-semibold">
+							{{ $group->sponsorship_contact_email }}
+						</a>
+					</div>
+				</div>
+			</div>
+		@endif
+	</div>
+@endif

--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -66,6 +66,11 @@
 			</a>
 		</div>
 	</div>
+
+	{{-- Sponsorship Info --}}
+	@if($group->hasSponsorship())
+		<x-sponsorship-info :group="$group" />
+	@endif
 	
 	{{-- Upcoming Meetup --}}
 	@isset($next_meetup)

--- a/resources/views/world/sponsorships.blade.php
+++ b/resources/views/world/sponsorships.blade.php
@@ -1,0 +1,279 @@
+<x-layout>
+	
+	<x-slot:og>
+		<meta property="og:url" content="{{ url()->current() }}" />
+		<meta property="og:type" content="website" />
+		<meta property="og:title" content="Sponsorships - PHP×" />
+		<meta property="og:description" content="Support PHP and Laravel meetups worldwide. Learn how to sponsor groups or add sponsorship options to your group." />
+		<meta property="og:image" content="{{ asset('world/og.jpg') }}" />
+	</x-slot:og>
+	
+	<div class="max-w-4xl mx-auto">
+		
+		<div class="flex flex-col gap-6">
+			<h1 class="font-mono font-semibold text-white text-4xl sm:text-6xl">
+				Sponsorships
+			</h1>
+			
+			<p class="text-gray-300 text-lg">
+				PHP× connects sponsors with local PHP and Laravel meetups worldwide. Whether you want to support the community or add sponsorship options to your group, this page has everything you need.
+			</p>
+		</div>
+		
+		<!-- For Sponsors Section -->
+		<section class="mt-12">
+			<h2 class="font-mono font-semibold text-white text-3xl mb-6">
+				For Sponsors
+			</h2>
+			
+			<div class="space-y-6 text-gray-300">
+				<p class="text-lg">
+					Looking to support the PHP and Laravel community? Our meetups are always looking for sponsors to help make events happen and grow the community.
+				</p>
+				
+				<div class="bg-white/5 rounded-lg p-6 border border-white/5">
+					<h3 class="font-semibold text-white text-xl mb-4">Why Sponsor PHP× Groups?</h3>
+					<ul class="space-y-2">
+						<li class="flex items-start gap-3">
+							<svg class="w-5 h-5 text-green-400 mt-1 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+								<path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd" />
+							</svg>
+							<span><strong>Connect with developers:</strong> Reach passionate PHP and Laravel developers in local communities</span>
+						</li>
+						<li class="flex items-start gap-3">
+							<svg class="w-5 h-5 text-green-400 mt-1 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+								<path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd" />
+							</svg>
+							<span><strong>Build brand awareness:</strong> Get your company name in front of engaged technical audiences</span>
+						</li>
+						<li class="flex items-start gap-3">
+							<svg class="w-5 h-5 text-green-400 mt-1 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+								<path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd" />
+							</svg>
+							<span><strong>Support the community:</strong> Help maintain and grow the PHP ecosystem globally</span>
+						</li>
+						<li class="flex items-start gap-3">
+							<svg class="w-5 h-5 text-green-400 mt-1 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+								<path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd" />
+							</svg>
+							<span><strong>Talent pipeline:</strong> Meet potential hires in a relaxed, community setting</span>
+						</li>
+					</ul>
+				</div>
+				
+				<div class="bg-blue-500/10 border border-blue-500/20 rounded-lg p-6">
+					<h3 class="font-semibold text-blue-300 text-xl mb-3">Get Connected</h3>
+					<p class="text-blue-100 mb-4">
+						The best way to connect with groups is through our Discord community, where organizers and sponsors can meet and discuss opportunities.
+					</p>
+					<a href="https://discord.gg/wMy6Eeuwbu" target="_blank" class="inline-flex items-center gap-2 bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-lg font-semibold transition-colors">
+						<svg class="w-5 h-5" viewBox="0 0 24 24" fill="currentColor">
+							<path d="M20.317 4.37a19.791 19.791 0 0 0-4.885-1.515.074.074 0 0 0-.079.037c-.21.375-.444.864-.608 1.25a18.27 18.27 0 0 0-5.487 0 12.64 12.64 0 0 0-.617-1.25.077.077 0 0 0-.079-.037A19.736 19.736 0 0 0 3.677 4.37a.07.07 0 0 0-.032.027C.533 9.046-.32 13.58.099 18.057a.082.082 0 0 0 .031.057 19.9 19.9 0 0 0 5.993 3.03.078.078 0 0 0 .084-.028 14.09 14.09 0 0 0 1.226-1.994.076.076 0 0 0-.041-.106 13.107 13.107 0 0 1-1.872-.892.077.077 0 0 1-.008-.128 10.2 10.2 0 0 0 .372-.292.074.074 0 0 1 .077-.01c3.928 1.793 8.18 1.793 12.062 0a.074.074 0 0 1 .078.01c.12.098.246.198.373.292a.077.077 0 0 1-.006.127 12.299 12.299 0 0 1-1.873.892.077.077 0 0 0-.041.107c.36.698.772 1.362 1.225 1.993a.076.076 0 0 0 .084.028 19.839 19.839 0 0 0 6.002-3.03.077.077 0 0 0 .032-.054c.5-5.177-.838-9.674-3.549-13.66a.061.061 0 0 0-.031-.03zM8.02 15.33c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.956-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.956 2.418-2.157 2.418zm7.975 0c-1.183 0-2.157-1.085-2.157-2.419 0-1.333.955-2.419 2.157-2.419 1.21 0 2.176 1.096 2.157 2.42 0 1.333-.946 2.418-2.157 2.418Z"/>
+						</svg>
+						Join PHP× Discord
+					</a>
+				</div>
+			</div>
+		</section>
+
+		<!-- Groups Looking for Sponsors -->
+		@if($groupsWithSponsorship->count() > 0)
+			<section class="mt-12">
+				<h2 class="font-mono font-semibold text-white text-3xl mb-6">
+					Groups Looking for Sponsors
+				</h2>
+				
+				<p class="text-gray-300 mb-8">
+					The following PHP× groups are actively seeking sponsorship. Click on any group to visit their page and see their specific sponsorship packages.
+				</p>
+				
+				<div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+					@foreach($groupsWithSponsorship as $group)
+						<div class="bg-white/5 rounded-lg p-6 border border-white/5 hover:bg-white/10 transition-colors">
+							<div class="flex items-start justify-between mb-4">
+								<h3 class="font-semibold text-white text-lg">{{ $group->name }}</h3>
+								@if($group->region)
+									<span class="text-sm text-gray-400 bg-gray-700 px-2 py-1 rounded">
+										{{ $group->region }}
+									</span>
+								@endif
+							</div>
+							
+							@if($group->description)
+								<p class="text-gray-300 text-sm mb-4 line-clamp-3">
+									{{ $group->description }}
+								</p>
+							@endif
+							
+							<div class="space-y-3">
+								<!-- Package Preview -->
+								@if(count($group->sponsorship_packages) > 0)
+									<div class="border-t border-white/10 pt-3">
+										<p class="text-xs text-gray-400 mb-2">Available packages:</p>
+										@foreach($group->sponsorship_packages as $package)
+											<div class="text-sm text-gray-300">
+												<span class="font-medium text-white">{{ $package['name'] }}</span>
+												<span class="text-gray-400">
+													- {{ strtoupper($package['currency']) }} ${{ number_format($package['amount']) }}
+												</span>
+											</div>
+										@endforeach
+									</div>
+								@endif
+								
+								<!-- Contact & Visit -->
+								<div class="flex flex-col gap-2 pt-3 border-t border-white/10">
+									@if($group->sponsorship_contact_email)
+										<a href="mailto:{{ $group->sponsorship_contact_email }}" 
+										   class="text-sm text-blue-400 hover:text-blue-300 transition-colors">
+											Contact: {{ $group->sponsorship_contact_email }}
+										</a>
+									@endif
+									<a href="https://{{ $group->domain }}" 
+									   class="text-sm text-green-400 hover:text-green-300 transition-colors">
+										Visit group page →
+									</a>
+								</div>
+							</div>
+						</div>
+					@endforeach
+				</div>
+			</section>
+		@endif
+
+		<!-- For Group Organizers Section -->
+		<section class="mt-16">
+			<h2 class="font-mono font-semibold text-white text-3xl mb-6">
+				For Group Organizers
+			</h2>
+			
+			<div class="space-y-8 text-gray-300">
+				
+				<div class="bg-white/5 rounded-lg p-6 border border-white/5">
+					<h3 class="font-semibold text-white text-xl mb-4">Adding Sponsorship to Your Group</h3>
+					<p class="mb-4">
+						You can now add sponsorship information to your group's page! This feature allows you to:
+					</p>
+					<ul class="space-y-2 mb-6">
+						<li class="flex items-start gap-3">
+							<svg class="w-5 h-5 text-green-400 mt-1 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+								<path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd" />
+							</svg>
+							<span>Define multiple sponsorship packages with different price tiers</span>
+						</li>
+						<li class="flex items-start gap-3">
+							<svg class="w-5 h-5 text-green-400 mt-1 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+								<path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd" />
+							</svg>
+							<span>List specific benefits for each sponsorship level</span>
+						</li>
+						<li class="flex items-start gap-3">
+							<svg class="w-5 h-5 text-green-400 mt-1 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+								<path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd" />
+							</svg>
+							<span>Display on your group page and in the PHP× network</span>
+						</li>
+						<li class="flex items-start gap-3">
+							<svg class="w-5 h-5 text-green-400 mt-1 flex-shrink-0" fill="currentColor" viewBox="0 0 20 20">
+								<path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd" />
+							</svg>
+							<span>Provide easy contact information for potential sponsors</span>
+						</li>
+					</ul>
+					
+					<div class="bg-gray-900 rounded-lg p-4">
+						<p class="text-sm font-semibold text-white mb-2">Add to your groups.json:</p>
+						<pre class="text-sm text-green-300 overflow-x-auto"><code>"sponsorships": {
+  "enabled": true,
+  "description": "Support our local PHP community",
+  "contact_email": "sponsors@yourgroup.com",
+  "packages": [
+    {
+      "name": "Gold Sponsor",
+      "currency": "USD",
+      "amount": 500,
+      "benefits": [
+        "Logo on all event materials",
+        "5-minute speaking slot",
+        "Social media mention",
+        "Newsletter inclusion"
+      ]
+    },
+    {
+      "name": "Silver Sponsor",
+      "currency": "USD",
+      "amount": 250,
+      "benefits": [
+        "Logo on event materials",
+        "Social media mention"
+      ]
+    }
+  ]
+}</code></pre>
+					</div>
+				</div>
+
+				<div class="bg-yellow-500/10 border border-yellow-500/20 rounded-lg p-6">
+					<h3 class="font-semibold text-yellow-300 text-xl mb-4">Best Practices for Getting Sponsors</h3>
+					
+					<div class="space-y-4">
+						<div>
+							<h4 class="font-semibold text-yellow-200 mb-2">Keep It Simple (KISS)</h4>
+							<p class="text-yellow-100">
+								Sponsors want simplicity. Make it easy for them—the easier it is, the more likely a sponsorship will succeed. 
+								Don't enforce complex logistics or complicate things by having sponsors for specific things (unless they specifically ask).
+							</p>
+						</div>
+						
+						<div>
+							<h4 class="font-semibold text-yellow-200 mb-2">Set Clear Rates</h4>
+							<p class="text-yellow-100">
+								Set a simple sponsorship rate for all sponsors. If you can do it in an international currency (e.g. USD), even better.
+							</p>
+						</div>
+						
+						<div>
+							<h4 class="font-semibold text-yellow-200 mb-2">Core Proposition</h4>
+							<p class="text-yellow-100 mb-2">Have a core proposition (but be prepared to be flexible):</p>
+							<ul class="space-y-1 text-yellow-100 text-sm">
+								<li>• Shout outs on social media before, during and after the event</li>
+								<li>• Mentions in the next group newsletter</li>
+								<li>• Logos on screens (physical and digital) at the event</li>
+								<li>• Possible swag items (if you don't mind the logistics)</li>
+								<li>• MC thanks sponsors by name during the event</li>
+								<li>• Possible short sponsor speaking slot</li>
+							</ul>
+						</div>
+						
+						<div>
+							<h4 class="font-semibold text-yellow-200 mb-2">Professional Invoicing</h4>
+							<p class="text-yellow-100 mb-2">Prepare proper invoices with all necessary details:</p>
+							<ul class="space-y-1 text-yellow-100 text-sm">
+								<li>• Date of invoice and due date</li>
+								<li>• Currency and amount to be paid</li>
+								<li>• Your address and their address</li>
+								<li>• A unique invoice number</li>
+								<li>• Your payment details (Wise is a good option)</li>
+							</ul>
+						</div>
+						
+						<div class="pt-4 border-t border-yellow-500/20">
+							<p class="font-semibold text-yellow-200">
+								Remember: The keys to successful sponsor relations are good communication and effective execution. 
+								Be clear about expectations and deliver what you promised.
+							</p>
+						</div>
+					</div>
+				</div>
+			</div>
+		</section>
+		
+		<div class="mt-16 pt-8 border-t border-white/10">
+			<p class="text-center text-gray-400">
+				<a href="/" class="hover:text-white transition-colors">← Back to PHP× World</a>
+			</p>
+		</div>
+	
+	</div>
+
+</x-layout>

--- a/routes/web.php
+++ b/routes/web.php
@@ -2,6 +2,7 @@
 
 use App\Enums\RootDomains;
 use App\Http\Controllers\World\HomeController;
+use App\Http\Controllers\World\SponsorshipsController;
 use App\Http\Middleware\SetGroupFromDomainMiddleware;
 use App\Http\Middleware\ShareNextMeetupMiddleware;
 use App\Models\Meetup;
@@ -11,6 +12,7 @@ use Illuminate\Support\Facades\Route;
 foreach (RootDomains::cases() as $case) {
 	Route::domain($case->value)->group(function() {
 		Route::get('/', HomeController::class);
+		Route::get('/sponsorships', SponsorshipsController::class);
 		Route::view('/terms', 'world.terms');
 	});
 }

--- a/tests/Feature/SponsorshipFeatureTest.php
+++ b/tests/Feature/SponsorshipFeatureTest.php
@@ -1,0 +1,147 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Actions\SyncGroups;
+use App\Models\Group;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SponsorshipFeatureTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_group_can_have_sponsorship_enabled(): void
+    {
+        $group = Group::factory()->create([
+            'sponsorships_enabled' => true,
+            'sponsorship_packages' => [
+                [
+                    'name' => 'Gold Sponsor',
+                    'currency' => 'USD',
+                    'amount' => 500,
+                    'benefits' => ['Logo on materials', 'Speaking slot']
+                ]
+            ],
+            'sponsorship_contact_email' => 'sponsors@example.com',
+            'sponsorship_description' => 'Support our community'
+        ]);
+
+        $this->assertTrue($group->acceptsSponsorship());
+        $this->assertTrue($group->hasSponsorship());
+    }
+
+    public function test_group_without_sponsorship_packages_returns_false_for_has_sponsorship(): void
+    {
+        $group = Group::factory()->create([
+            'sponsorships_enabled' => true,
+            'sponsorship_packages' => []
+        ]);
+
+        $this->assertTrue($group->acceptsSponsorship());
+        $this->assertFalse($group->hasSponsorship());
+    }
+
+    public function test_sync_sponsorship_processes_sponsorship_data(): void
+    {
+        $group = Group::factory()->create([
+            'domain' => 'test.domain',
+            'name' => 'Test Group'
+        ]);
+
+        $sponsorshipConfig = [
+            'sponsorships' => [
+                'enabled' => true,
+                'packages' => [
+                    [
+                        'name' => 'Silver Sponsor',
+                        'currency' => 'USD', 
+                        'amount' => 250,
+                        'benefits' => ['Social media mention']
+                    ]
+                ],
+                'contact_email' => 'sponsors@test.com',
+                'description' => 'Test sponsorship'
+            ]
+        ];
+
+        $syncAction = new SyncGroups();
+        $reflection = new \ReflectionClass($syncAction);
+        $method = $reflection->getMethod('syncSponsorship');
+        $method->setAccessible(true);
+        
+        $method->invoke($syncAction, $group, $sponsorshipConfig);
+
+        $this->assertTrue($group->sponsorships_enabled);
+        $this->assertEquals('sponsors@test.com', $group->sponsorship_contact_email);
+        $this->assertEquals('Test sponsorship', $group->sponsorship_description);
+        $this->assertCount(1, $group->sponsorship_packages);
+        $this->assertEquals('Silver Sponsor', $group->sponsorship_packages[0]['name']);
+    }
+
+    public function test_sync_groups_handles_missing_sponsorship_data(): void
+    {
+        $group = Group::factory()->create([
+            'domain' => 'test.domain',
+            'name' => 'Test Group'
+        ]);
+
+        // Simulate syncSponsorship with no sponsorship data
+        $syncAction = new SyncGroups();
+        $reflection = new \ReflectionClass($syncAction);
+        $method = $reflection->getMethod('syncSponsorship');
+        $method->setAccessible(true);
+        
+        $method->invoke($syncAction, $group, []); // Empty config
+
+        $this->assertFalse($group->sponsorships_enabled);
+        $this->assertNull($group->sponsorship_contact_email);
+        $this->assertNull($group->sponsorship_description);
+        $this->assertEmpty($group->sponsorship_packages);
+    }
+
+    public function test_api_includes_sponsorship_data_for_groups_with_sponsorship(): void
+    {
+        $group = Group::factory()->create([
+            'domain' => 'testdomain.com',
+            'sponsorships_enabled' => true,
+            'sponsorship_packages' => [
+                [
+                    'name' => 'Gold Sponsor',
+                    'currency' => 'USD',
+                    'amount' => 500,
+                    'benefits' => ['Logo placement', 'Speaking time']
+                ]
+            ],
+            'sponsorship_contact_email' => 'sponsors@testdomain.com',
+            'sponsorship_description' => 'Support our community'
+        ]);
+
+        $response = $this->getJson('/api/groups');
+
+        $response->assertStatus(200);
+        
+        // Verify the group has sponsorship data
+        $group->refresh(); // Reload from database
+        $this->assertTrue($group->hasSponsorship());
+        
+        $responseData = $response->json();
+        $this->assertTrue($responseData['groups']['testdomain.com']['sponsorship']['enabled']);
+        $this->assertEquals('sponsors@testdomain.com', $responseData['groups']['testdomain.com']['sponsorship']['contact_email']);
+        $this->assertEquals('Gold Sponsor', $responseData['groups']['testdomain.com']['sponsorship']['packages'][0]['name']);
+    }
+
+    public function test_api_excludes_sponsorship_data_for_groups_without_sponsorship(): void
+    {
+        $group = Group::factory()->create([
+            'domain' => 'nosponsor.com',
+            'sponsorships_enabled' => false
+        ]);
+
+        $response = $this->getJson('/api/groups');
+
+        $response->assertStatus(200);
+        $responseData = $response->json();
+        $this->assertArrayNotHasKey('sponsorship', $responseData['groups']['nosponsor.com']);
+    }
+}


### PR DESCRIPTION
This PR adds support for new options to the `groups.json` structure to allow groups to define sponsorship opportunities, as well as offering instructions for both group organizers and potential sponsors around how this all works.

See screenshots below for examples of how it works.

```
"sponsorships": {
  "enabled": true,
  "description": "Support our local PHP community",
  "contact_email": "sponsors@yourgroup.com",
  "packages": [
    {
      "name": "Gold Sponsor",
      "currency": "USD",
      "amount": 500,
      "benefits": [
        "Logo on all event materials",
        "5-minute speaking slot",
        "Social media mention",
        "Newsletter inclusion"
      ]
    },
    {
      "name": "Silver Sponsor",
      "currency": "USD",
      "amount": 250,
      "benefits": [
        "Logo on event materials",
        "Social media mention"
      ]
    }
  ]
}
```

### Meetup site
<img width="907" height="742" alt="Screenshot 2025-08-31 at 15 01 25" src="https://github.com/user-attachments/assets/0d950c44-63a3-4d19-a731-7a462bd9e0a6" />

### World Site - new `/sponsorships` page
<img width="3024" height="6660" alt="screencapture-phpx-test-sponsorships-2025-08-31-17_28_40" src="https://github.com/user-attachments/assets/39d9639f-bb80-4d79-84fc-79ccb3c1f654" />
